### PR TITLE
fix condition embedding (concat) & test text emb recovery

### DIFF
--- a/ContextMRI/pipeline_mri.py
+++ b/ContextMRI/pipeline_mri.py
@@ -175,7 +175,7 @@ class MRIDiffusionPipeline(DiffusionPipeline):
 
         latents = latents * self.scheduler.init_noise_sigma
         return latents
-    
+
     def denoise_latents(
         self,
         latents,
@@ -198,16 +198,15 @@ class MRIDiffusionPipeline(DiffusionPipeline):
             # conditioning embeddings
             if metadata_list is not None and hasattr(self.unet, "condition_emb"):
                 cond_emb = self.unet.condition_emb(
-                    metadata_list, 
-                    dtype=latent_model_input.dtype, 
-                    device=latent_model_input.device
+                    metadata_list,
+                    dtype=latent_model_input.dtype,
+                    device=latent_model_input.device,
                 )
-                cur_prompt_embeds = prompt_embeds + cond_emb.unsqueeze(1)
+                # cur_prompt_embeds = prompt_embeds + cond_emb.unsqueeze(1)
+                cur_prompt_embeds = torch.cat([prompt_embeds, cond_emb], dim=1)
 
             noise_pred = self.unet(
-                latent_model_input, 
-                t, 
-                encoder_hidden_states=cur_prompt_embeds
+                latent_model_input, t, encoder_hidden_states=cur_prompt_embeds
             )[0]
 
             if guidance_scale > 1:
@@ -222,7 +221,14 @@ class MRIDiffusionPipeline(DiffusionPipeline):
         return latents
 
     @torch.no_grad()
-    def sample(self, prompt, guidance_scale, num_inference_steps, eta=0.0,metadata_list: Optional[List[Dict[str, Any]]] = None):
+    def sample(
+        self,
+        prompt,
+        guidance_scale,
+        num_inference_steps,
+        eta=0.0,
+        metadata_list: Optional[List[Dict[str, Any]]] = None,
+    ):
         skip = 1000 // num_inference_steps
 
         # 1. Encode input prompt
@@ -251,20 +257,17 @@ class MRIDiffusionPipeline(DiffusionPipeline):
             at_prev = self.alpha(t - skip)
 
             xt_in = torch.cat([xt] * 2) if guidance_scale > 1 else xt
-            
+
             # KEY CHANGE
             cur_prompt_embeds = prompt_embeds
             if metadata_list is not None and hasattr(self.unet, "condition_emb"):
                 cond_emb = self.unet.condition_emb(
-                    metadata_list,
-                    dtype=xt_in.dtype,
-                    device=xt_in.device
+                    metadata_list, dtype=xt_in.dtype, device=xt_in.device
                 )
-                cur_prompt_embeds = prompt_embeds + cond_emb.unsqueeze(1)
+                # cur_prompt_embeds = prompt_embeds + cond_emb.unsqueeze(1)
+                cur_prompt_embeds = torch.cat([prompt_embeds, cond_emb], dim=1)
 
-            noise_pred = self.unet(
-                xt_in, t, encoder_hidden_states=cur_prompt_embeds
-            )[0]
+            noise_pred = self.unet(xt_in, t, encoder_hidden_states=cur_prompt_embeds)[0]
             if guidance_scale > 1:
                 noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
                 noise_pred = noise_pred_uncond + guidance_scale * (
@@ -375,7 +378,7 @@ class MRIDiffusionPipeline(DiffusionPipeline):
         gamma=5.0,
         CG_iter=5,
         save_dir=None,
-        metadata_list: Optional[List[Dict[str, Any]]] = None  # <-- New parameter
+        metadata_list: Optional[List[Dict[str, Any]]] = None,  # <-- New parameter
     ):
         skip = 1000 // num_inference_steps
 
@@ -406,17 +409,16 @@ class MRIDiffusionPipeline(DiffusionPipeline):
             at_prev = self.alpha(t - skip)
 
             xt_in = torch.cat([xt] * 2) if cfg_guidance else xt
-            
+
             # NEW: Incorporate conditioning metadata if provided.
             cur_prompt_embeds = prompt_embeds
             if metadata_list is not None and hasattr(self.unet, "condition_emb"):
                 cond_emb = self.unet.condition_emb(
-                    metadata_list,
-                    dtype=xt_in.dtype,
-                    device=xt_in.device
+                    metadata_list, dtype=xt_in.dtype, device=xt_in.device
                 )
-                cur_prompt_embeds = prompt_embeds + cond_emb.unsqueeze(1)
-            
+                # cur_prompt_embeds = prompt_embeds + cond_emb.unsqueeze(1)
+                cur_prompt_embeds = torch.cat([prompt_embeds, cond_emb], dim=1)
+
             noise_pred = noise_pred_uncond = self.unet(
                 xt_in, t, encoder_hidden_states=cur_prompt_embeds
             )[0]
@@ -513,7 +515,7 @@ class MRIDiffusionPipeline(DiffusionPipeline):
             extra_step_kwargs,
             num_inference_steps,
             guidance_scale,
-            metadata_list=metadata_list  # <-- New!
+            metadata_list=metadata_list,  # <-- New!
         )
 
         latents = latents.squeeze().detach().cpu().numpy()

--- a/ContextMRI/test_hengjui/finetune_mri.sh
+++ b/ContextMRI/test_hengjui/finetune_mri.sh
@@ -19,11 +19,11 @@ accelerate launch --num_processes=1 --num_machines=1 train_mri.py \
   --output_dir $output_dir \
   --mixed_precision="fp16" \
   --resolution=320 \
-  --train_batch_size=1 \
-  --gradient_accumulation_steps=1 \
+  --train_batch_size=2 \
+  --gradient_accumulation_steps=4 \
   --learning_rate=5e-5 \
   --report_to="tensorboard" \
-  --lr_scheduler="constant" \
+  --lr_scheduler="linear" \
   --lr_warmup_steps=1000 \
   --max_train_steps=10000 \
   --checkpointing_steps=100 \

--- a/ContextMRI/test_hengjui/metadata_stats.json
+++ b/ContextMRI/test_hengjui/metadata_stats.json
@@ -1,0 +1,81 @@
+{
+    "anatomy": [
+        "brain",
+        "knee"
+    ],
+    "slice_number": {
+        "min": 0.0,
+        "max": 30.0
+    },
+    "contrast": [
+        "AX",
+        "AX T1 POST_FBB",
+        "AX T1 PRE_FBB",
+        "AX T2_FBB",
+        "AX FLAIR_FBB",
+        "AX T1_FBB",
+        "PD",
+        "PDFS"
+    ],
+    "sequence": [
+        "TurboSpinEcho",
+        "Flash"
+    ],
+    "TR": {
+        "min": 247.0,
+        "max": 15810.0
+    },
+    "TE": {
+        "min": 2.0,
+        "max": 126.0
+    },
+    "TI": {
+        "min": 100.0,
+        "max": 2500.0
+    },
+    "flip_angle": {
+        "min": 69.0,
+        "max": 180.0
+    },
+    "pathology": [
+        "Nonspecific white matter lesion",
+        "Posttreatment change",
+        "craniotomy",
+        "Nonspecific lesion",
+        "Possible artifact",
+        "Normal for age",
+        "Dural thickening",
+        "Enlarged ventricles",
+        "Edema",
+        "Resection cavity",
+        "Small vessel chronic white matter ischemic change",
+        "mass",
+        "encephalomalacia",
+        "Lacunar infarct",
+        "Extra-axial mass",
+        "Normal variant",
+        "Paranasal sinus opacification",
+        "Craniectomy",
+        "Craniectomy with cranioplasty",
+        "Motion artifact",
+        "Meniscus tear",
+        "Cartilage - partial thickness loss/defect",
+        "Joint effusion",
+        "Bone-fracture/contusion/dislocation",
+        "Bone-subchondral edema",
+        "Periarticular cysts",
+        "Ligament - ACL low grade sprain",
+        "Ligament - ACL high grade sprain",
+        "Cartilage - full thickness loss/defect",
+        "Ligament - MCL low-mod grade sprain",
+        "Displaced meniscal tissue",
+        "Bone - lesion",
+        "LCL complex - low-mod grade sprain",
+        "Ligament - PCL low-mod grade sprain",
+        "Muscle strain",
+        "Soft tissue lesion",
+        "Joint bodies",
+        "Ligament - PCL high grade",
+        "LCL complext - high grade sprain"
+    ]
+}

--- a/ContextMRI/test_hengjui/test_condition_emb.py
+++ b/ContextMRI/test_hengjui/test_condition_emb.py
@@ -88,6 +88,7 @@ def test_condition_emb(metadata_stats: str):
     if isinstance(emb, torch.Tensor):
         assert emb.shape == (
             2,
+            9,
             emb_dim,
         ), f"Expected shape (2, {emb_dim}), but got {emb.shape}"
     print("Condition embedding test passed. (cfg_strategy: independent)")
@@ -104,6 +105,7 @@ def test_condition_emb(metadata_stats: str):
     if isinstance(emb, torch.Tensor):
         assert emb.shape == (
             2,
+            9,
             emb_dim,
         ), f"Expected shape (2, {emb_dim}), but got {emb.shape}"
     print("Condition embedding test passed. (cfg_strategy: joint)")

--- a/ContextMRI/test_hengjui/text_emb_recover.py
+++ b/ContextMRI/test_hengjui/text_emb_recover.py
@@ -1,0 +1,425 @@
+import argparse
+from collections import defaultdict
+import json
+import math
+import random
+
+import torch
+from torch import nn
+from torch.utils.data import Dataset, DataLoader
+from transformers import CLIPTokenizer, CLIPTextModel
+from tqdm import tqdm
+
+
+class PredictionModule(nn.Module):
+    def __init__(self, emb_size, num_classes):
+        super().__init__()
+
+        self.query = nn.Parameter(torch.randn(1, 1, emb_size))
+        self.attention = nn.MultiheadAttention(emb_size, num_heads=12, batch_first=True)
+        self.layer_norm = nn.LayerNorm(emb_size)
+        self.linear = nn.Linear(emb_size, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (batch_size, seq_len, emb_size)
+        # self.query: (1, 1, emb_size)
+
+        # Expand query to match batch size
+        query = self.query.expand(x.size(0), -1, -1)  # (batch_size, 1, emb_size)
+        # Apply attention
+        x, _ = self.attention(query, x, x)  # (batch_size, 1, emb_size)
+        x = x.squeeze(1)
+        # Apply layer normalization
+        x = self.layer_norm(x)
+        # Apply linear layer
+        x = self.linear(x)  # (batch_size, num_classes)
+
+        return x
+
+
+def load_clip_text_encoder(pretrained_dir: str):
+    tokenizer = CLIPTokenizer.from_pretrained(pretrained_dir, subfolder="tokenizer")
+    text_encoder = CLIPTextModel.from_pretrained(
+        pretrained_dir, subfolder="text_encoder"
+    )
+    return tokenizer, text_encoder
+
+
+def encode_text(prompt, tokenizer, text_encoder, device, max_length=77):
+    if max_length is not None:
+        tokenizer_max_length = max_length
+    else:
+        tokenizer_max_length = tokenizer.model_max_length
+
+    inputs = tokenizer(
+        prompt,
+        return_tensors="pt",
+        padding="max_length",
+        truncation=True,
+        max_length=tokenizer_max_length,
+    )
+    input_ids = inputs.input_ids.to(device)
+    attention_mask = None
+
+    with torch.no_grad():
+        text_embeddings = text_encoder(
+            input_ids=input_ids, attention_mask=attention_mask
+        )[0]
+
+    return text_embeddings
+
+
+def generate_prompt(
+    anatomy: str,
+    slice_number: int = None,
+    contrast: str = None,
+    sequence: str = None,
+    TR: float = None,
+    TE: float = None,
+    TI: float = None,
+    flip_angle: float = None,
+    pathology: str = None,
+) -> str:
+    prompt = f"{anatomy}"
+    if slice_number is not None:
+        prompt += f", Slice {slice_number}"
+    if contrast is not None:
+        prompt += f", {contrast}"
+    if pathology is not None:
+        prompt += f", Pathology: {random.randint(1, 3)} {pathology}"
+    if sequence is not None:
+        prompt += f", Sequence: {sequence}"
+    if TR is not None:
+        prompt += f", TR: {TR:.2f}"
+    if TE is not None:
+        prompt += f", TE: {TE:.2f}"
+    if TI is not None:
+        prompt += f", TI: {TI:.2f}"
+    if flip_angle is not None:
+        prompt += f", Flip angle: {flip_angle:.2f}"
+
+    return prompt
+
+
+class PromptDataset(Dataset):
+    def __init__(self, metadata_stats: str):
+        with open(metadata_stats, "r") as f:
+            self.metadata = json.load(f)
+
+        self.attributes = [
+            key for key, value in self.metadata.items() if len(value) > 1
+        ]
+        self.categorical_dict = {
+            key: {k: i for i, k in enumerate(value)}
+            for key, value in self.metadata.items()
+            if len(value) > 1 and isinstance(value, list)
+        }
+
+        print(f"Attributes: {self.attributes}")
+        print(f"Categorical attributes: {self.categorical_dict.keys()}")
+
+    def __len__(self):
+        return 1024
+
+    def __getitem__(self, index):
+        sampled = {}
+        sampled["anatomy"] = self.metadata["anatomy"][
+            random.randint(0, len(self.metadata["anatomy"]) - 1)
+        ]
+        sampled["slice_number"] = random.randint(
+            int(self.metadata["slice_number"]["min"]),
+            int(self.metadata["slice_number"]["max"]),
+        )
+        sampled["sequence"] = self.metadata["sequence"][
+            random.randint(0, len(self.metadata["sequence"]) - 1)
+        ]
+        sampled["contrast"] = self.metadata["contrast"][
+            random.randint(0, len(self.metadata["contrast"]) - 1)
+        ]
+        sampled["TR"] = random.uniform(
+            float(self.metadata["TR"]["min"]), float(self.metadata["TR"]["max"])
+        )
+        sampled["TE"] = random.uniform(
+            float(self.metadata["TE"]["min"]), float(self.metadata["TE"]["max"])
+        )
+        sampled["TI"] = random.uniform(
+            float(self.metadata["TI"]["min"]), float(self.metadata["TI"]["max"])
+        )
+        sampled["flip_angle"] = random.uniform(
+            float(self.metadata["flip_angle"]["min"]),
+            float(self.metadata["flip_angle"]["max"]),
+        )
+        sampled["pathology"] = self.metadata["pathology"][
+            random.randint(0, len(self.metadata["pathology"]) - 1)
+        ]
+
+        prompt = generate_prompt(**sampled)
+        label = {}
+        for key in self.attributes:
+            if key in self.categorical_dict:
+                label[key] = self.categorical_dict[key][sampled[key]]
+            else:
+                label[key] = (sampled[key] - float(self.metadata[key]["min"])) / (
+                    float(self.metadata[key]["max"]) - float(self.metadata[key]["min"])
+                )
+                # normalize to [0, 1]
+        return prompt, label
+
+
+def collate_fn(batch):
+    prompts = []
+    labels = defaultdict(list)
+    for prompt, label in batch:
+        prompts.append(prompt)
+        for key, value in label.items():
+            labels[key].append(value)
+
+    for key, value in labels.items():
+        labels[key] = torch.tensor(value)
+
+    return prompts, labels
+
+
+def fix_seed(seed: int):
+    random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def get_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Text Encoder")
+    parser.add_argument(
+        "--pretrained_dir",
+        type=str,
+        required=True,
+        help="Path to pretrained model directory",
+    )
+    parser.add_argument(
+        "--metadata_stats",
+        type=str,
+        required=True,
+        help="Path to metadata_stats.json file",
+    )
+
+    # Training
+    parser.add_argument(
+        "--lr",
+        type=float,
+        default=1e-3,
+        help="Learning rate for the optimizer",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=64,
+        help="Batch size for training",
+    )
+    parser.add_argument(
+        "--num_updates",
+        type=int,
+        default=1000,
+        help="Number of updates for training",
+    )
+
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for reproducibility",
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    args = get_args()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Using device: {device}")
+
+    # Fix random seed for reproducibility
+    fix_seed(args.seed)
+
+    # Load the tokenizer and text encoder
+    tokenizer, text_encoder = load_clip_text_encoder(args.pretrained_dir)
+    text_encoder.to(device)
+    text_encoder.eval()
+    emb_size = text_encoder.config.projection_dim
+
+    # Create the dataset and dataloader
+    train_set = PromptDataset(args.metadata_stats)
+    train_loader = DataLoader(
+        train_set,
+        batch_size=args.batch_size,
+        shuffle=True,
+        collate_fn=collate_fn,
+        pin_memory=True,
+        drop_last=True,
+    )
+    test_set = PromptDataset(args.metadata_stats)
+    test_loader = DataLoader(
+        test_set,
+        batch_size=args.batch_size,
+        shuffle=False,
+        collate_fn=collate_fn,
+        drop_last=False,
+    )
+
+    # Numerical / categorical attributes
+    numerical_attributes = [
+        key for key in train_set.attributes if key not in train_set.categorical_dict
+    ]
+    categorical_attributes = [
+        key for key in train_set.attributes if key in train_set.categorical_dict
+    ]
+
+    # Initialize linear probes
+    linear_probes = nn.ModuleDict()
+    for key in numerical_attributes:
+        linear_probes[key] = PredictionModule(emb_size, 1)
+    for key in categorical_attributes:
+        linear_probes[key] = PredictionModule(
+            emb_size, len(train_set.categorical_dict[key])
+        )
+    linear_probes.to(device)
+    linear_probes.train()
+
+    # Initialize optimizer
+    optimizer = torch.optim.Adam(
+        linear_probes.parameters(),
+        lr=args.lr,
+        weight_decay=1e-4,
+    )
+
+    # Initialize loss function
+    numerical_loss_fn = nn.MSELoss()
+    categorical_loss_fn = nn.CrossEntropyLoss()
+
+    # Training loop
+    print("Starting training...")
+    num_epochs = int(math.ceil(args.num_updates / len(train_loader)))
+    pbar = tqdm(total=args.num_updates, desc="Training")
+    for epoch in range(num_epochs):
+        for prompts, labels in train_loader:
+            optimizer.zero_grad()
+
+            # Encode text
+            with torch.no_grad():
+                text_embeddings = encode_text(
+                    prompts,
+                    tokenizer,
+                    text_encoder,
+                    device,
+                )
+
+            # Move labels to device
+            for key, value in labels.items():
+                labels[key] = value.to(device)
+
+            # Forward pass
+            outputs = {}
+            for key, probe in linear_probes.items():
+                outputs[key] = probe(text_embeddings)
+            loss = 0
+            for key in numerical_attributes:
+                loss += numerical_loss_fn(outputs[key].squeeze(), labels[key].float())
+            for key in categorical_attributes:
+                loss += categorical_loss_fn(outputs[key], labels[key].long().squeeze())
+
+            # Backward pass
+            loss.backward()
+            optimizer.step()
+            pbar.update(1)
+            pbar.set_postfix(loss=loss.item())
+    pbar.close()
+    print("Training completed.")
+
+    # Evaluation loop
+    print("Evaluating...")
+    fix_seed(args.seed)
+    linear_probes.eval()
+    numerical_mse = defaultdict(list)
+    categorical_acc = defaultdict(list)
+    with torch.no_grad():
+        for prompts, labels in tqdm(test_loader):
+            # Encode text
+            text_embeddings = encode_text(
+                prompts,
+                tokenizer,
+                text_encoder,
+                device,
+            )
+
+            # Move labels to device
+            for key, value in labels.items():
+                labels[key] = value.to(device)
+
+            # Forward pass
+            outputs = {}
+            for key, probe in linear_probes.items():
+                outputs[key] = probe(text_embeddings)
+            for key in numerical_attributes:
+                numerical_mse[key].append(
+                    numerical_loss_fn(
+                        outputs[key].squeeze(), labels[key].float()
+                    ).item()
+                )
+            for key in categorical_attributes:
+                categorical_acc[key].append(
+                    (outputs[key].argmax(dim=-1) == labels[key].long())
+                    .float()
+                    .mean()
+                    .item()
+                )
+    print("Evaluation completed.")
+
+    # Calculate average metrics
+    numerical_mse_avg = {
+        key: sum(values) / len(values) for key, values in numerical_mse.items()
+    }
+    categorical_acc_avg = {
+        key: sum(values) / len(values) for key, values in categorical_acc.items()
+    }
+    print("Numerical MSE:")
+    for key, value in numerical_mse_avg.items():
+        print(f"  {key}: {value:.4f}")
+    print("Categorical Accuracy:")
+    for key, value in categorical_acc_avg.items():
+        print(f"  {key}: {value:.4f}")
+
+
+if __name__ == "__main__":
+    main()
+
+"""
+python3 test_hengjui/text_emb_recover.py \
+    --pretrained_dir /data/sls/scratch/hengjui/6S982/pretrained/MRI_checkpoint \
+    --metadata_stats /data/sls/r/u/hengjui/home/scratch/6S982/mri-project/ContextMRI/test_hengjui/metadata_stats.json \
+    --lr 1e-4 \
+    --batch_size 256 \
+    --num_updates 1000
+
+==== Results ====
+Using device: cuda
+Attributes: ['anatomy', 'slice_number', 'contrast', 'sequence', 'TR', 'TE', 'TI', 'flip_angle', 'pathology']
+Categorical attributes: dict_keys(['anatomy', 'contrast', 'sequence', 'pathology'])
+Attributes: ['anatomy', 'slice_number', 'contrast', 'sequence', 'TR', 'TE', 'TI', 'flip_angle', 'pathology']
+Categorical attributes: dict_keys(['anatomy', 'contrast', 'sequence', 'pathology'])
+Starting training...
+Training: 100%|██████████████████████████████████████████████████████████████████████| 1000/1000 [08:47<00:00,  1.89it/s, loss=0.00983]
+Training completed.
+Evaluating...
+100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:01<00:00,  2.14it/s]
+Evaluation completed.
+Numerical MSE:
+  slice_number: 0.0002
+  TR: 0.0041
+  TE: 0.0020
+  TI: 0.0027
+  flip_angle: 0.0010
+Categorical Accuracy:
+  anatomy: 1.0000
+  contrast: 1.0000
+  sequence: 1.0000
+  pathology: 1.0000
+"""

--- a/ContextMRI/train_mri.py
+++ b/ContextMRI/train_mri.py
@@ -424,9 +424,11 @@ def main(args):
                         metadata_list, dtype=weight_dtype, device=accelerator.device
                     )
                     if text_embeddings is None:
-                        text_embeddings = cond_embeddings.unsqueeze(1)
+                        text_embeddings = cond_embeddings
                     else:
-                        text_embeddings = text_embeddings + cond_embeddings.unsqueeze(1)
+                        text_embeddings = torch.cat(
+                            [text_embeddings, cond_embeddings], dim=1
+                        )
 
                 # Sample noise that we'll add to the latents
                 noise = torch.randn_like(model_input)


### PR DESCRIPTION
The original CLIP text embeddings have a shape of `(batch size, 77, 768)` but the condition embeddings were summed in a shape of `(batch size, 1, 768)` and added to the text embeddings. This PR fixed the issue by concatenating all condition embeddings from each attribute to a sequence. For instance, we have 8 attributes in the metadata, the condition embeddings would look like:
```python3
# text_emb: (batch_size, 77, 768)
# cond_emb: (batch_size, 8 + 1, 768) -> [ [SEP] token, Cond_1, Cond_2, ..., Cond_8 ]
text_emb = torch.cat([text_emb, cond_emb], dim=1)  # (batch_size, 86, 768)
```
See ContextMRI/modules/condition_emb.py, ContextMRI/pipeline_mri.py, and ContextMRI/train_mri.py for more information.

I also added **layernorm** to the condition embedding layer output so that it learns to adjust the scale of the embeddings to match the original CLIP text embeddings.

---

The fine-tuning script is modified so that it uses
1. Linear warmup LR scheduler
2. Gradient accumulation

---

ContextMRI/test_hengjui/text_emb_recover.py tests to see if we can recover the information (numerical and categorical) from the encoded CLIP text embeddings.
